### PR TITLE
Trying to move over to some more standard package format - esm

### DIFF
--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,4 +1,4 @@
-import EventEmitter = require('events')
+import { EventEmitter } from 'events'
 
 /**
  * Level of the log entry
@@ -28,7 +28,7 @@ export class Logger {
    *
    * @param context logger context
    */
-  static getLogger(context) {
+  static getLogger(context: any) {
     let name = ''
     if (typeof context === 'function') name = context.name
     else if (typeof context === 'object') name = (<any>context).constructor.name
@@ -46,7 +46,7 @@ export class Logger {
    * @param event event to react to
    * @param handler event handler
    */
-  static on(event: LoggerEvents, handler: (context, level, message) => void) {
+  static on(event: LoggerEvents, handler: (context: any, level: LogLevel, message: string) => void) {
     this.events.on(event, handler)
   }
 

--- a/lib/mavlink.ts
+++ b/lib/mavlink.ts
@@ -466,7 +466,7 @@ export class MavLinkPacket {
       + `seq: ${this.header.seq}, `
       + `plen: ${this.header.payloadLength}, `
     // @ts-ignore
-    + `magic: ${this.constructor['MAGIC_NUMBER']} (${hex(this.constructor['MAGIC_NUMBER'])}), `
+    + `magic: ${MSG_ID_MAGIC_NUMBER[this.header.msgid]} (${hex(MSG_ID_MAGIC_NUMBER[this.header.msgid])}), `
       + `crc: ${hex(this.crc, 4)}`
     // @ts-ignore
     + this.signatureToString(this.signature)

--- a/lib/serialization.test.ts
+++ b/lib/serialization.test.ts
@@ -4,11 +4,13 @@ describe('serialization', () => {
   describe('char', () => {
     it('will serialize char', () => {
       const b = Buffer.from([0])
+      // @ts-ignore
       SERIALIZERS['char'](42, b, 0)
       expect(b).toStrictEqual(Buffer.from([42]))
     })
     it('will deserialize char', () => {
       const b = Buffer.from([42])
+      // @ts-ignore
       const result = DESERIALIZERS['char'](b, 0)
       expect(result).toBe('*')
     })
@@ -27,11 +29,13 @@ describe('serialization', () => {
   describe('uint8_t', () => {
     it('will serialize 8-bit unsigned int', () => {
       const b = Buffer.from([0])
+      // @ts-ignore
       SERIALIZERS['uint8_t'](2, b, 0)
       expect(b).toStrictEqual(Buffer.from([2]))
     })
     it('will deserialize 8-bit unsigned int', () => {
       const b = Buffer.from([2])
+      // @ts-ignore
       const result = DESERIALIZERS['uint8_t'](b, 0)
       expect(result).toBe(2)
     })
@@ -50,11 +54,13 @@ describe('serialization', () => {
   describe('int8_t', () => {
     it('will serialize 8-bit signed int', () => {
       const b = Buffer.from([0])
+      // @ts-ignore
       SERIALIZERS['int8_t'](-2, b, 0)
       expect(b).toStrictEqual(Buffer.from([-2]))
     })
     it('will deserialize 8-bit signed int', () => {
       const b = Buffer.from([-2])
+      // @ts-ignore
       const result = DESERIALIZERS['int8_t'](b, 0)
       expect(result).toBe(-2)
     })
@@ -73,11 +79,13 @@ describe('serialization', () => {
   describe('uint16_t', () => {
     it('will serialize 16-bit unsigned int', () => {
       const b = Buffer.from([0, 0])
+      // @ts-ignore
       SERIALIZERS['uint16_t'](2, b, 0)
       expect(b).toStrictEqual(Buffer.from([2, 0]))
     })
     it('will deserialize 16-bit unsigned int', () => {
       const b = Buffer.from([2, 0])
+      // @ts-ignore
       const result = DESERIALIZERS['uint16_t'](b, 0)
       expect(result).toBe(2)
     })
@@ -96,11 +104,13 @@ describe('serialization', () => {
   describe('int16_t', () => {
     it('will serialize 16-bit signed int', () => {
       const b = Buffer.from([0, 0])
+      // @ts-ignore
       SERIALIZERS['int16_t'](-2, b, 0)
       expect(b).toStrictEqual(Buffer.from([254, 255]))
     })
     it('will deserialize 16-bit signed int', () => {
       const b = Buffer.from([254, 255])
+      // @ts-ignore
       const result = DESERIALIZERS['int16_t'](b, 0)
       expect(result).toBe(-2)
     })
@@ -119,11 +129,13 @@ describe('serialization', () => {
   describe('uint32_t', () => {
     it('will serialize 32-bit unsigned int', () => {
       const b = Buffer.from([0, -1, -2, -3])
+      // @ts-ignore
       SERIALIZERS['uint32_t'](2, b, 0)
       expect(b).toStrictEqual(Buffer.from([2, 0, 0, 0]))
     })
     it('will deserialize 32-bit unsigned int', () => {
       const b = Buffer.from([2, 0, 0, 0])
+      // @ts-ignore
       const result = DESERIALIZERS['uint32_t'](b, 0)
       expect(result).toBe(2)
     })
@@ -142,11 +154,13 @@ describe('serialization', () => {
   describe('int32_t', () => {
     it('will serialize 32-bit signed int', () => {
       const b = Buffer.from([0, 0, 0, 0])
+      // @ts-ignore
       SERIALIZERS['int32_t'](-2, b, 0)
       expect(b).toStrictEqual(Buffer.from([254, 255, 255, 255]))
     })
     it('will deserialize 32-bit signed int', () => {
       const b = Buffer.from([254, 255, 255, 255])
+      // @ts-ignore
       const result = DESERIALIZERS['int32_t'](b, 0)
       expect(result).toBe(-2)
     })
@@ -165,11 +179,13 @@ describe('serialization', () => {
   describe('uint64_t', () => {
     it('will serialize 64-bit unsigned int', () => {
       const b = Buffer.from([0, -1, -2, -3, -4, -5, -6, -7])
+      // @ts-ignore
       SERIALIZERS['uint64_t'](2n, b, 0)
       expect(b).toStrictEqual(Buffer.from([2, 0, 0, 0, 0, 0, 0, 0]))
     })
     it('will deserialize 64-bit unsigned int', () => {
       const b = Buffer.from([2, 0, 0, 0, 0, 0, 0, 0])
+      // @ts-ignore
       const result = DESERIALIZERS['uint64_t'](b, 0)
       expect(result).toBe(2n)
     })
@@ -188,11 +204,13 @@ describe('serialization', () => {
   describe('int64_t', () => {
     it('will serialize 64-bit signed int', () => {
       const b = Buffer.from([0, 0, 0, 0, 0, 0, 0, 0])
+      // @ts-ignore
       SERIALIZERS['int64_t'](-2n, b, 0)
       expect(b).toStrictEqual(Buffer.from([254, 255, 255, 255, 255, 255, 255, 255]))
     })
     it('will deserialize 64-bit signed int', () => {
       const b = Buffer.from([254, 255, 255, 255, 255, 255, 255, 255])
+      // @ts-ignore
       const result = DESERIALIZERS['int64_t'](b, 0)
       expect(result).toBe(-2n)
     })
@@ -211,11 +229,13 @@ describe('serialization', () => {
   describe('float', () => {
     it('will serialize float', () => {
       const b = Buffer.from([0, -1, -2, -3])
+      // @ts-ignore
       SERIALIZERS['float'](2.5, b, 0)
       expect(b).toStrictEqual(Buffer.from([0, 0, 32, 64]))
     })
     it('will deserialize float', () => {
       const b = Buffer.from([0, 0, 32, 192])
+      // @ts-ignore
       const result = DESERIALIZERS['float'](b, 0)
       expect(result).toBe(-2.5)
     })
@@ -234,11 +254,13 @@ describe('serialization', () => {
   describe('double', () => {
     it('will serialize double', () => {
       const b = Buffer.from([0, -1, -2, -3, -4, -5, -6, -7])
+      // @ts-ignore
       SERIALIZERS['double'](2.34, b, 0)
       expect(b).toStrictEqual(Buffer.from([184, 30, 133, 235, 81, 184, 2, 64]))
     })
     it('will deserialize double', () => {
       const b = Buffer.from([184, 30, 133, 235, 81, 184, 2, 64])
+      // @ts-ignore
       const result = DESERIALIZERS['double'](b, 0)
       expect(result).toBe(2.34)
     })

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -35,9 +35,9 @@ export function dump(buffer: Buffer, lineWidth = 16) {
 /**
  * Sleep for a given number of miliseconds
  *
- * @param ms number of miliseconds to sleep
+ * @param {number} ms of miliseconds to sleep
  */
-export function sleep(ms) {
+export function sleep(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 
@@ -48,11 +48,11 @@ export function sleep(ms) {
  * a particular expression should be evaluated and how long will it take to end
  * the execution without success. Great for time-sensitive operations.
  *
- * @param cb callback to call every <code>interval</code>ms
+ * @param cb callback to call every <code>interval</code>ms. Waiting stops if the callback returns a truthy value.
  * @param timeout number of miliseconds that need to pass before the Timeout exception is thrown
  * @param interval number of miliseconds before re-running the callback
  */
-export async function waitFor(cb, timeout = 10000, interval = 100) {
+export async function waitFor<T>(cb: () => T, timeout = 10000, interval = 100): Promise<T> {
   return new Promise((resolve, reject) => {
     const timeoutTimer = setTimeout(() => {
       cleanup()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "node-mavlink",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-mavlink",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "LGPL",
       "dependencies": {
-        "mavlink-mappings": "^1.0.9-20220424"
+        "mavlink-mappings": "^1.0.11-20220706"
       },
       "devDependencies": {
         "@types/jest": "^27.4.1",
@@ -3800,9 +3800,9 @@
       }
     },
     "node_modules/mavlink-mappings": {
-      "version": "1.0.9-20220424",
-      "resolved": "https://registry.npmjs.org/mavlink-mappings/-/mavlink-mappings-1.0.9-20220424.tgz",
-      "integrity": "sha512-KBrUfxrCaDuWST+zUe+L3rwDYm9aRp0FD5jWzevXywlLlvhW1sWx0ahp9TVdGCV0+7kOoGGFpxziQGiwrIqT9g==",
+      "version": "1.0.11-20220706",
+      "resolved": "https://registry.npmjs.org/mavlink-mappings/-/mavlink-mappings-1.0.11-20220706.tgz",
+      "integrity": "sha512-Mhx30DGf7GfhHMAYkSBzythruTUkzrA5QSOB9Ttj/BxsV/Vmt5pV6d7w1F2Q/nbd8GE3QSx9jtDeEicFnc8OVw==",
       "funding": {
         "type": "patreon",
         "url": "https://www.patreon.com/padcom"
@@ -7951,9 +7951,9 @@
       }
     },
     "mavlink-mappings": {
-      "version": "1.0.9-20220424",
-      "resolved": "https://registry.npmjs.org/mavlink-mappings/-/mavlink-mappings-1.0.9-20220424.tgz",
-      "integrity": "sha512-KBrUfxrCaDuWST+zUe+L3rwDYm9aRp0FD5jWzevXywlLlvhW1sWx0ahp9TVdGCV0+7kOoGGFpxziQGiwrIqT9g=="
+      "version": "1.0.11-20220706",
+      "resolved": "https://registry.npmjs.org/mavlink-mappings/-/mavlink-mappings-1.0.11-20220706.tgz",
+      "integrity": "sha512-Mhx30DGf7GfhHMAYkSBzythruTUkzrA5QSOB9Ttj/BxsV/Vmt5pV6d7w1F2Q/nbd8GE3QSx9jtDeEicFnc8OVw=="
     },
     "merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-mavlink",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "author": "Matthias Hryniszak <padcom@gmail.com>",
   "license": "LGPL",
   "description": "MavLink definitions and parsing library",
@@ -22,15 +22,16 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
-    "mavlink-mappings": "^1.0.9-20220424"
+    "mavlink-mappings": "^1.0.11-20220706"
   },
   "scripts": {
-    "build": "tsc && minimize-js dist",
+    "clean": "rm -rf dist lib/*.js",
+    "build": "tsc",
     "test": "jest && npm run test:batch",
-    "test:batch": "npx ts-node tests/main.ts e2e --input tests/data.mavlink",
+    "test:batch": "npx ts-node tests/main.mts e2e --input tests/data.mavlink",
     "dev": "jest --watch",
-    "test:e2e": "cd tests && ./main.ts e2e --input data.mavlink",
-    "prepublishOnly": "rm -rf dist && npm install && npm run build && npm test"
+    "test:e2e": "cd tests && ./main.mts e2e --input data.mavlink",
+    "prepublishOnly": "npm run clean && npm install && npm test && npm run build"
   },
   "devDependencies": {
     "@types/jest": "^27.4.1",

--- a/sanity-check.js
+++ b/sanity-check.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+const { SerialPort } = require('serialport')
+const { createMavLinkStream } = require('.')
+
+const port = new SerialPort({ path: '/dev/ttyACM0', baudRate: 57600, autoOpen: true })
+const parser = createMavLinkStream(port)
+parser.on('data', packet => console.log(packet.debug()))

--- a/tests/main.mts
+++ b/tests/main.mts
@@ -1,4 +1,4 @@
-#!/usr/bin/env ts-node
+#!/usr/bin/env -S npx ts-node
 
 import yargs from 'yargs'
 import { existsSync, createReadStream } from 'fs'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,107 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
-    "lib": ["ES2020", "DOM"],
-    "target": "es2020",
-    "declaration": true,
-    "outDir": "./dist",
-    "esModuleInterop": true
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Projects */
+    // "incremental": true,                              /* Enable incremental compilation */
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./",                          /* Specify the folder for .tsbuildinfo incremental compilation files. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "es2020",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "lib": [                                             /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+      "ES2020",
+      "DOM"
+    ],
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h' */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx*`.` */
+    // "reactNamespace": "",                             /* Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+
+    /* Modules */
+    "module": "CommonJS",                                  /* Specify what module code is generated. */
+    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "moduleResolution": "node",                          /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like `./node_modules/@types`. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "resolveJsonModule": true,                        /* Enable importing .json files */
+    // "noResolve": true,                                /* Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`. */
+
+    /* Emit */
+    "declaration": true,                                 /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    "declarationMap": true,                              /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output. */
+    "outDir": "./dist",                                  /* Specify an output folder for all emitted files. */
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have `@internal` in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like `__extends` in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing `const enum` declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": false,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+
+    /* Type Checking */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied `any` type.. */
+    // "strictNullChecks": true,                         /* When type checking, take into account `null` and `undefined`. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for `bind`, `call`, and `apply` methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "noImplicitThis": true,                           /* Enable error reporting when `this` is given the type `any`. */
+    // "useUnknownInCatchVariables": true,               /* Type catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when a local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Include 'undefined' in index signature results */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
   },
-  "include": [
-    "index.ts",
-  ],
   "exclude": [
-    "node_modules"
+    "**/*.test.ts"
   ]
 }


### PR DESCRIPTION
## Purpose: adapt to standards in packaging

So this PR is probably going to modify how the library is distributed a lot. It will contain only ES6 modules, which means that older, unsupported versions of node.js just will not work.