### PR TITLE
Add option to set target IP address to MavEsp8266 module

### DIFF
--- a/lib/mavesp.ts
+++ b/lib/mavesp.ts
@@ -52,9 +52,11 @@ export class MavEsp8266 extends EventEmitter {
    *
    * @param receivePort port to receive messages on (default: 14550)
    * @param sendPort port to send messages to (default: 14555)
+   * @param ip IP address to send to in case there is no broadcast (default: empty string)
    */
-  async start(receivePort: number = 14550, sendPort: number = 14555): Promise<ConnectionInfo> {
+  async start(receivePort: number = 14550, sendPort: number = 14555, ip: string = ''): Promise<ConnectionInfo> {
     this.sendPort = sendPort
+    this.ip = ip;
 
     // Create a UDP socket
     this.socket = createSocket({ type: 'udp4', reuseAddr: true })


### PR DESCRIPTION
This allows the MavEsp8266 module to work with an endpoint in UDPCI mode which doesn't do broadcasts. 

An optional parameter is added to the `start` function to set a specific target IP address. It is specifically added to the end of the parameter list in order to make sure that both `receivePort` and `sendPort` are also specified.

Issue link: #31 