### PR TITLE
fix(waitFor): Correct interval handling and cleanup logic

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -60,16 +60,21 @@ export async function waitFor<T>(cb: () => T, timeout = 10000, interval = 100): 
     }, timeout)
 
     const intervalTimer = setInterval(() => {
-      const result = cb()
-      if (result) {
+      try {
+        const result = cb()
+        if (result) {
+          cleanup()
+          resolve(result)
+        }
+      } catch (error) {
         cleanup()
-        resolve(result)
+        reject(error)
       }
-    })
+    }, interval)
 
     const cleanup = () => {
       clearTimeout(timeoutTimer)
-      clearTimeout(intervalTimer)
+      clearInterval(intervalTimer)
     }
   })
 }


### PR DESCRIPTION
- Added missing `interval` argument to `setInterval` to ensure it respects the intended delay between executions.
- Fixed incorrect `clearTimeout(intervalTimer)`, replacing it with `clearInterval(intervalTimer)`.
- Wrapped `cb()` execution in a try-catch block to handle errors.

This fixes a bug where `waitFor` would ignore interval amount and not clear intervals properly, leading to potential unexpected behavior.